### PR TITLE
feat: Update Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 # and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   check:
@@ -110,7 +110,7 @@ jobs:
             include:
             - runner: ubuntu-latest
               target: x86_64-unknown-linux-musl
-              make_cmd: build-release
+              make_cmd: build-release-x86_64
             - runner: ubuntu-24.04-arm
               target: armv7-unknown-linux-musleabihf
               make_cmd: build-release-armv7

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: run cargo target-x86_64-unknown-linux-musl target-armv7-unknown-linux-musleabihf build-debug build-release build-release-armv7 publish publish-dry-run check check-clippy check-fmt clean fix fix-clippy fix-fmt lock lock-upgrade test sdist wheel
+.PHONY: run cargo \
+			target-x86_64-unknown-linux-musl target-armv7-unknown-linux-musleabihf \
+			build-debug build-release-x86_64 build-release-armv7 \
+			publish publish-dry-run \
+			check check-clippy check-fmt clean \
+			fix fix-clippy fix-fmt \
+			lock lock-upgrade \
+			test sdist wheel
 
 # This is the first target, so it is run if "make" is called without arguments.
 run: $(CARGO)
@@ -18,22 +25,24 @@ $(CARGO):
 # Install cargo.
 cargo: $(CARGO)
 
-# Install the x86_64-unknown-linux-musl target if not already installed.
-target-x86_64-unknown-linux-musl: $(CARGO)
-	if ! $(RUSTUP) target list | grep -q 'x86_64-unknown-linux-musl (installed)'; then \
-	  $(RUSTUP) target add x86_64-unknown-linux-musl; \
+# Generic macro to install a Rust target if not already installed.
+define install-rust-target
+	if ! $(RUSTUP) target list | grep -q '$(1) (installed)'; then \
+	  $(RUSTUP) target add $(1); \
 	fi
+endef
+
+target-x86_64-unknown-linux-musl: $(CARGO)
+	$(call install-rust-target,x86_64-unknown-linux-musl)
 
 target-armv7-unknown-linux-musleabihf: $(CARGO)
-	if ! $(RUSTUP) target list | grep -q 'armv7-unknown-linux-musleabihf (installed)'; then \
-	  $(RUSTUP) target add armv7-unknown-linux-musleabihf; \
-	fi
+	$(call install-rust-target,armv7-unknown-linux-musleabihf)
 
-# Build the project for the x86_64-unknown-linux-musl target.
-build-debug: $(CARGO) target-x86_64-unknown-linux-musl
-	$(CARGO) build --target x86_64-unknown-linux-musl
+# Build the project.
+build-debug: $(CARGO)
+	$(CARGO) build
 
-build-release: $(CARGO) target-x86_64-unknown-linux-musl
+build-release-x86_64: $(CARGO) target-x86_64-unknown-linux-musl
 	$(CARGO) build --target x86_64-unknown-linux-musl --locked --release
 
 build-release-armv7: $(CARGO) target-armv7-unknown-linux-musleabihf


### PR DESCRIPTION
Explicit build for x86_64 and add template for adding a new target

Also fixed so `cancel-in-progress` is always set to `true`, as `github.head_ref` will only be set for PRs
